### PR TITLE
do not standardize SRO field (yet)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,9 +18,8 @@ overrides:
   - files:
       - '*.test.js'
     rules:
-      func-names:            off
-      prefer-arrow-callback: off
       max-nested-callbacks:  off
+      no-invalid-this:       off
       no-magic-numbers:      off
       no-param-reassign:     off
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,7 +39,9 @@ rules:
     - warn
     - 3
   max-params: warn
-  max-statements: warn
+  max-statements:
+    - warn
+    - 15
   max-statements-per-line:
     - warn
     - max: 2

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/lib/convert.CW.js
+++ b/lib/convert.CW.js
@@ -18,15 +18,6 @@ const mappings = {
 };
 
 /**
- * The transforms table is passed to the @digitallinguistics/toolbox2json library as an option. It contains functions that apply transformations to the data contained in the specified fields.
- * @type {Object}
- */
-const transforms = {
-  dl:  processDialects,
-  sro: processSRO,
-};
-
-/**
  * Create a human-readable key from a lemma
  * @param  {String} lemma The lemma, including hyphens
  * @return {String}       Returns an ASCII key with no spaces or hyphens
@@ -126,16 +117,6 @@ function getDefinitions(input) {
  */
 function hasWhitespace(str) {
   return /\s/u.test(str);
-}
-
-/**
- * Checks whether a string contains only valid SRO characters.
- * @param  {String}  str The string to check
- * @return {Boolean}
- */
-function isValidSRO(str) {
-  const sroCharsRegExp = /^(?:[-êiîoôaâptkcmnshwy]|\s)+$/u;
-  return sroCharsRegExp.test(str);
 }
 
 /**
@@ -371,22 +352,6 @@ function processNote(...args) {
 }
 
 /**
- * Standardize an SRO transcription
- * @param  {String} string The string to standardize
- * @return {String}
- */
-function processSRO(string) {
-  return [string]
-  .map(str => str.normalize())
-  .map(str => str.replace(/ń/gu, `y`)) // U+0144
-  .map(str => str.replace(/ý/gu, `y`)) // U+00FD
-  .map(str => {
-    validateSROChars(str);
-    return str;
-  })[0];
-}
-
-/**
  * Extract the usage note and save it to the sense
  * @param  {String} noteText
  * @param  {Object} entry
@@ -425,20 +390,6 @@ function removeUnusedDefinition(noteText, entry, sense) {
 
 }
 
-/**
- * Throws an error if a string contains any invalid SRO characters
- * @param  {string} str The string to validate
- */
-function validateSROChars(str) {
-  if (!isValidSRO(str)) {
-    Array.from(str).forEach((char, i) => {
-      if (!isValidSRO(char)) {
-        throw new Error(`Character <${ char }> at position ${ i } is invalid`);
-      }
-    });
-  }
-}
-
 export default async function convertCW(inputPath, outputPath) {
 
   if (!inputPath) {
@@ -455,7 +406,9 @@ export default async function convertCW(inputPath, outputPath) {
     out:        outputPath,
     parseError: `object`,
     postprocessor,
-    transforms,
+    transforms: {
+      dl: processDialects,
+    },
   });
 
 }

--- a/lib/convert.CW.js
+++ b/lib/convert.CW.js
@@ -378,8 +378,8 @@ function processNote(...args) {
 function processSRO(string) {
   return [string]
   .map(str => str.normalize())
-  .map(str => str.replace(/ń/gu, 'y')) // U+0144
-  .map(str => str.replace(/ý/gu, 'y')) // U+00FD
+  .map(str => str.replace(/ń/gu, `y`)) // U+0144
+  .map(str => str.replace(/ý/gu, `y`)) // U+00FD
   .map(str => {
     validateSROChars(str);
     return str;
@@ -433,7 +433,7 @@ function validateSROChars(str) {
   if (!isValidSRO(str)) {
     Array.from(str).forEach((char, i) => {
       if (!isValidSRO(char)) {
-        throw new Error(`Character <${char}> at position ${i} is invalid`);
+        throw new Error(`Character <${ char }> at position ${ i } is invalid`);
       }
     });
   }

--- a/lib/convert.CW.test.js
+++ b/lib/convert.CW.test.js
@@ -23,7 +23,7 @@ const outPath      = joinPaths(__dirname, `../test/CW.test.json`);
  */
 function getTestEntry(ctx) {
   const matchedEntry = ctx.data.filter(entry => entry.test === ctx.test.title).shift();
-  if (!matchedEntry) expect.fail(`No test database entry found for test "${ctx.test.title}"`);
+  if (!matchedEntry) expect.fail(`No test database entry found for test "${ ctx.test.title }"`);
   return matchedEntry;
 }
 
@@ -183,10 +183,8 @@ describe(`CW conversion script`, function() {
 
     it(`produces an error object for invalid SRO characters`, function() {
 
-      const { name, message } = this.data.filter(item => {
-        return item.name === `ParseError`
-        && item.lines.some(line => line.includes(this.test.title));
-      }).shift();
+      const { name, message } = this.data.filter(item => item.name === `ParseError`
+        && item.lines.some(line => line.includes(this.test.title))).shift();
 
       expect(name).to.equal(`ParseError`);
       expect(message).to.contain(`invalid`);

--- a/lib/convert.CW.test.js
+++ b/lib/convert.CW.test.js
@@ -164,31 +164,9 @@ describe(`CW conversion script`, function() {
 
   context(`\\sro`, function() {
 
-    it(`converts <ý> to <y>`, function() {
+    it(`copies the SRO field verbatim`, function() {
       const { lemma } = getTestEntry(this);
-      expect(lemma.sro).to.equal(`y`);
-    });
-
-    it(`converts <ń> to <y>`, function() {
-      const { lemma } = getTestEntry(this);
-      expect(lemma.sro).to.equal(`y`);
-    });
-
-    it(`NFC normalizes`, function() {
-      // Cannot test this with <ý> because it gets converted to <y>.
-      // test data: <ê> (non-normalized)
-      const { lemma } = getTestEntry(this);
-      expect(lemma.sro).to.equal(`ê`);
-    });
-
-    it(`produces an error object for invalid SRO characters`, function() {
-
-      const { name, message } = this.data.filter(item => item.name === `ParseError`
-        && item.lines.some(line => line.includes(this.test.title))).shift();
-
-      expect(name).to.equal(`ParseError`);
-      expect(message).to.contain(`invalid`);
-
+      expect(lemma.sro).to.equal(`acicipaýihow`);
     });
 
   });

--- a/test/CW.test.db
+++ b/test/CW.test.db
@@ -14,14 +14,11 @@
 \dl   Cree: pC
 \dl   Cree: sC
 
-\test converts <ń> to <y>
-\sro  ń
-
-\test converts <ý> to <y>
-\sro  ý
-
 \test converts dialects to Glottocodes
 \dl   Cree: npC
+
+\test copies the SRO field verbatim
+\sro  acicipaýihow
 
 \test copies the Syllabics field verbatim
 \syl  ᐊᒑᐦᑯᐢ  ᐁᑳ  ᑳ ᐋᐦᒌᐟ
@@ -55,12 +52,6 @@
 
 \test extracts usage notes
 \def  insistently; [in negative clauses:] (not) necessarily
-
-\test NFC normalizes
-\sro  ê
-
-\test produces an error object for invalid SRO characters
-\sro  z
 
 \test separates definitions by semicolons
 \def  it is a star; s/he is a star (e.g. in movies, sports, music, etc.)

--- a/test/CW.test.json
+++ b/test/CW.test.json
@@ -2,9 +2,8 @@
 {"key":"kakito2","lemma":{"sro":"kâkito"},"senses":[],"test":"assigns homograph numbers"}
 {"key":"kahtiskawew","lemma":{"sro":"kâhtiskawêw"},"senses":[],"test":"assigns keys to each entry"}
 {"dialects":["plai1258","swam1239"],"key":"","lemma":{},"senses":[],"test":"combines multiple dialect codes"}
-{"key":"y","lemma":{"sro":"y"},"senses":[],"test":"converts <ń> to <y>"}
-{"key":"y2","lemma":{"sro":"y"},"senses":[],"test":"converts <ý> to <y>"}
 {"dialects":["nort2960"],"key":"2","lemma":{},"senses":[],"test":"converts dialects to Glottocodes"}
+{"key":"acicipayihow","lemma":{"sro":"acicipaýihow"},"senses":[],"test":"copies the SRO field verbatim"}
 {"key":"3","lemma":{"syll":"ᐊᒑᐦᑯᐢ  ᐁᑳ  ᑳ ᐋᐦᒌᐟ"},"senses":[],"test":"copies the Syllabics field verbatim"}
 {"definition":"North Star, Polaris; [lit: \"star that does not move\"]","key":"4","lemma":{},"senses":[{"definition":"North Star, Polaris"}],"test":"copies the original definition field verbatim","literalMeaning":"star that does not move","notes":[{"noteType":"general","text":"lit: \"star that does not move\""}]}
 {"definition":"not [cf. nama]","key":"5","lemma":{},"senses":[{"definition":"not","notes":[{"noteType":"general","text":"cf. nama"}]}],"test":"extracts compare relations: [cf. XXX]","lexicalRelations":[{"key":"nama","lemma":{"sro":"nama"},"relation":"compare"}]}
@@ -16,6 +15,4 @@
 {"definition":"dock [Lt. Rumex sp.; literally: \"yellow-root\"]","key":"11","lemma":{},"senses":[{"definition":"dock","scientificName":"Rumex sp.","notes":[{"noteType":"general","text":"Lt. Rumex sp."},{"noteType":"general","text":"literally: \"yellow-root\""}]}],"test":"extracts multiple notes from a parenthetical","literalMeaning":"yellow-root"}
 {"definition":"Christmas moon; December; literally: \"God-day moon, Christmas moon\"","key":"12","lemma":{},"senses":[{"definition":"Christmas moon"},{"definition":"December"}],"test":"extracts unbracketed literal definitions","literalMeaning":"God-day moon, Christmas moon"}
 {"definition":"insistently; [in negative clauses:] (not) necessarily","key":"13","lemma":{},"senses":[{"definition":"insistently"},{"definition":"(not) necessarily","usages":["in negative clauses"],"notes":[{"noteType":"general","text":"in negative clauses:"}]}],"test":"extracts usage notes"}
-{"key":"e","lemma":{"sro":"ê"},"senses":[],"test":"NFC normalizes"}
-{"lines":["\\test produces an error object for invalid SRO characters","\\sro  z"],"message":"Character <z> at position 0 is invalid","name":"ParseError"}
 {"definition":"it is a star; s/he is a star (e.g. in movies, sports, music, etc.)","key":"14","lemma":{},"senses":[{"definition":"it is a star"},{"definition":"s/he is a star (e.g. in movies, sports, music, etc.)"}],"test":"separates definitions by semicolons"}


### PR DESCRIPTION
The original version of the SRO field—with no normalization, substitutions, etc.—should be stored in the database, _in addition to_ standardized / normalized versions for itwêwina and the FST respectively.

The current `convert-cw` script does processing on the SRO field, so the original transcription is lost.

This PR removes any processing of the SRO field, and defers the process of standardizing / normalizing the SRO transcription until the point when the CW data is imported / aggregated into the ALTLab database (a forthcoming PR).

Partially addresses #44.