### PR TITLE
NDJSON database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,9 +107,15 @@ dist
 /scratch
 /data
 .eslintrc.js
+database.json
+database.ndjson
+database-*.json
+database-*.ndjson
 nodemon.json
 Maskwacis.json
+Maskwacis.ndjson
 Maskwacis.tsv
 MD-CW-mappings.tsv
 Wolvengrey.json
+Wolvengrey.ndjson
 Wolvengrey.toolbox

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ At a high level, the process for aggregating the sources is as follows:
 
 Please see the [style guide](./docs/style-guide.md) (with glossary) for documentation of the lexicographical conventions used in this database.
 
+## The Database
+
+The database is located in the private ALTLab repo at `crk/dicts/database-{hash}.ndjson`, where `{hash}` is an SHA1 hash of the database. This repo includes the following JavaScript utilities for working with the database, both located in `lib/utlities`.
+
+* `loadEntries.js`: Reads all the entries from the database (or any NDJSON file) into memory and returns a Promise that resolves to an Array of the entries for further querying and manipulation.
+* `saveDatabase.js`: Accepts an Array of database entries and saves it to the specified path as an NDJSON file with a trailing SHA1 hash.
+
 ## Building the Database
 
 1. Download the original data sources. These are stored in the private ALTLab repo in `crk/dicts`. **Do not commit these files to git.**

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Please see the [style guide](./docs/style-guide.md) (with glossary) for document
 
 2. Install the dependencies for this repo: `npm install`. This will also add the conversion scripts to the PATH (see next step).
 
-3. Once installed, you can convert individual data sources by running `convert-* <inputPath> <outPath>` from the command line, where `*` stands for the abbreviation of the data source, ex. `convert-cw Wolvengrey.toolbox CW.json`.
+3. Once installed, you can convert individual data sources by running `convert-* <inputPath> <outPath>` from the command line, where `*` stands for the abbreviation of the data source, ex. `convert-cw Wolvengrey.toolbox CW.ndjson`.
 
-4. You can also convert individual data sources by running the conversion scripts as modules. Each conversion script is located in `lib/convert.{ABBR}.js`, where `{ABBR}` stands for the abbreviation of the data source. Each module exports a function which takes two arguments: the path to the data source and optionally the path where you would like the converted data saved (this should have a `.json` extension). Each module returns an array of the converted entries as well.
+4. You can also convert individual data sources by running the conversion scripts as modules. Each conversion script is located in `lib/convert.{ABBR}.js`, where `{ABBR}` stands for the abbreviation of the data source. Each module exports a function which takes two arguments: the path to the data source and optionally the path where you would like the converted data saved (this should have a `.ndjson` extension). Each module returns an array of the converted entries as well.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please see the [style guide](./docs/style-guide.md) (with glossary) for document
 The database is located in the private ALTLab repo at `crk/dicts/database-{hash}.ndjson`, where `{hash}` is an SHA1 hash of the database. This repo includes the following JavaScript utilities for working with the database, both located in `lib/utlities`.
 
 * `loadEntries.js`: Reads all the entries from the database (or any NDJSON file) into memory and returns a Promise that resolves to an Array of the entries for further querying and manipulation.
-* `saveDatabase.js`: Accepts an Array of database entries and saves it to the specified path as an NDJSON file with a trailing SHA1 hash.
+* `saveDatabase.js`: Accepts an Array of database entries and saves it to the specified path as an NDJSON file with a trailing SHA1 hash. Note that by default the hash will be inserted into the provided filename: passing `database.ndjson` as the first argument to `saveDatabase.js` will save the file to `database-{hash}.ndjson`. You can disable this by passing `hash: false` as an option (in the options hash as the third argument to the function).
 
 ## Building the Database
 

--- a/lib/convert/CW.test.js
+++ b/lib/convert/CW.test.js
@@ -20,7 +20,7 @@ import {
 
 const __dirname  = getDirname(fileURLToPath(import.meta.url));
 const inputPath  = joinPaths(__dirname, '../../test/CW.test.db');
-const outputPath = joinPaths(__dirname, '../../test/CW.test.json');
+const outputPath = joinPaths(__dirname, '../../test/CW.test.ndjson');
 
 describe('CW conversion script', () => {
 

--- a/lib/convert/MD.test.js
+++ b/lib/convert/MD.test.js
@@ -20,7 +20,7 @@ import {
 
 const __dirname  = getDirname(fileURLToPath(import.meta.url));
 const inputPath  = joinPaths(__dirname, '../../test/MD.test.tsv');
-const outputPath = joinPaths(__dirname, '../../test/MD.test.json');
+const outputPath = joinPaths(__dirname, '../../test/MD.test.ndjson');
 
 describe('MD conversion script', () => {
 

--- a/lib/utilities/saveDatabase.js
+++ b/lib/utilities/saveDatabase.js
@@ -1,0 +1,41 @@
+import createHash                        from 'object-hash';
+import { stringify as createJSONStream } from 'ndjson';
+import { createWriteStream }             from 'fs';
+
+import {
+  basename as getBasename,
+  dirname  as getDirname,
+  extname  as getExtname,
+  join     as joinPath,
+} from 'path';
+
+/**
+ * Writes the entries Array to a JSON file.
+ * @param {String} outputPath The path where the JSON data should be written.
+ * @param {Array}  entries    The Array of entries to write to the file.
+ */
+export default function saveDatabase(outputPath, entries) {
+  return new Promise((resolve, reject) => {
+
+    const ext         = getExtname(outputPath);
+    const filename    = getBasename(outputPath, ext);
+    const dir         = getDirname(outputPath);
+    const hash        = createHash(entries);
+    const hashPath    = joinPath(dir, `${ filename }-${ hash }${ ext }`);
+
+    const jsonStream  = createJSONStream();
+    const writeStream = createWriteStream(hashPath);
+
+    jsonStream.on('error', reject);
+    writeStream.on('finish', resolve);
+    writeStream.on('close', resolve);
+    writeStream.on('error', reject);
+
+    jsonStream.pipe(writeStream);
+
+    entries.forEach(entry => jsonStream.write(entry));
+
+    jsonStream.end();
+
+  });
+}

--- a/lib/utilities/saveDatabase.js
+++ b/lib/utilities/saveDatabase.js
@@ -11,20 +11,22 @@ import {
 
 /**
  * Writes the entries Array to a JSON file.
- * @param {String} outputPath The path where the JSON data should be written.
- * @param {Array}  entries    The Array of entries to write to the file.
+ * @param {String}  outputPath          The path where the JSON data should be written. NOTE: The hash will be inserted before the extension when the file is written.
+ * @param {Array}   entries             The Array of entries to write to the file.
+ * @param {Object}  [options={}]        An options object.
+ * @param {Boolean} [options.hash=true] Whether to add the hash to the output filename.
  */
-export default function saveDatabase(outputPath, entries) {
+export default function saveDatabase(outputPath, entries, { hash = true } = {}) {
   return new Promise((resolve, reject) => {
 
     const ext         = getExtname(outputPath);
     const filename    = getBasename(outputPath, ext);
     const dir         = getDirname(outputPath);
-    const hash        = createHash(entries);
-    const hashPath    = joinPath(dir, `${ filename }-${ hash }${ ext }`);
+    const versionHash = createHash(entries);
+    const hashPath    = joinPath(dir, `${ filename }-${ versionHash }${ ext }`);
 
     const jsonStream  = createJSONStream();
-    const writeStream = createWriteStream(hashPath);
+    const writeStream = createWriteStream(hash ? hashPath : outputPath);
 
     jsonStream.on('error', reject);
     writeStream.on('finish', resolve);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,6 +1030,12 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "object-hash": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
+      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-chai-friendly": "^0.6.0",
     "mocha": "^8.3.2",
     "ndjson": "^2.0.0",
+    "object-hash": "^2.1.1",
     "progress": "^2.0.3"
   },
   "contributors": [


### PR DESCRIPTION
closes #16

Adds two utility scripts for working with the database:

* `loadEntries.js`
* `saveDatabase.js`

The `saveDatabase.js` utility saves the database with a version hash by default.